### PR TITLE
on-the-fly btag SF fix

### DIFF
--- a/Configurations/btagsfpatch.cc
+++ b/Configurations/btagsfpatch.cc
@@ -1,0 +1,241 @@
+/*
+  Temporary on-the-fly btag SF calculator for nanoLatino trees nAODv5_2016/2017/2018v5 or earlier.
+*/
+
+#include "LatinoAnalysis/MultiDraw/interface/TTreeFunction.h"
+#include "LatinoAnalysis/MultiDraw/interface/FunctionLibrary.h"
+
+#include "CondTools/BTau/test/BTagCalibrationStandalone.h"
+
+#include "TSystem.h"
+
+#include <string>
+#include <unordered_map>
+#include <iostream>
+#include <vector>
+#include <array>
+#include <string>
+
+class BtagSF : public multidraw::TTreeFunction {
+public:
+  BtagSF(char const* filename, char const* shift = "central", char const* algo = "deepcsv");
+
+  char const* getName() const override { return "BtagSF"; }
+  TTreeFunction* clone() const override { return new BtagSF(filename_.c_str(), shiftStr_.c_str(), algo_.c_str()); }
+
+  void beginEvent(long long) override;
+  int getMultiplicity() override { return 1; }
+  unsigned getNdata() override;
+  double evaluate(unsigned) override;
+
+protected:
+  void bindTree_(multidraw::FunctionLibrary&) override;
+
+  enum ShiftType {
+    kCentral,
+    kJESUp,
+    kJESDown,
+    kHFUp,
+    kHFDown,
+    kLFUp,
+    kLFDown,
+    kHFStats1Up,
+    kHFStats1Down,
+    kHFStats2Up,
+    kHFStats2Down,
+    kLFStats1Up,
+    kLFStats1Down,
+    kLFStats2Up,
+    kLFStats2Down,
+    kCFErr1Up,
+    kCFErr1Down,
+    kCFErr2Up,
+    kCFErr2Down,
+    nShiftTypes
+  };
+
+  std::string filename_{};
+
+  std::string shiftStr_{};
+  unsigned shift_{nShiftTypes};
+
+  std::string algo_{};
+
+  static long long currentEntry;
+  static UIntValueReader* nJet;
+  static FloatArrayReader* Jet_pt;
+  static FloatArrayReader* Jet_eta;
+  static IntArrayReader* Jet_hadronFlavour;
+  static FloatArrayReader* Jet_btag;
+
+  typedef std::array<std::unique_ptr<BTagCalibrationReader>, 3> Readers;
+  static Readers readers;
+  static std::string readerFilename;
+  static std::string readerAlgo;
+
+  static void setValues(long long);
+
+  static std::vector<std::array<double, nShiftTypes>> scalefactors;
+
+  static std::array<std::string, nShiftTypes> shiftNames;
+  static std::array<std::vector<unsigned>, 3> relevantShifts;
+};
+
+/*static*/
+BtagSF::Readers BtagSF::readers{};
+std::string BtagSF::readerFilename{};
+std::string BtagSF::readerAlgo{};
+long long BtagSF::currentEntry{-2};
+UIntValueReader* BtagSF::nJet{};
+FloatArrayReader* BtagSF::Jet_pt{};
+FloatArrayReader* BtagSF::Jet_eta{};
+IntArrayReader* BtagSF::Jet_hadronFlavour{};
+FloatArrayReader* BtagSF::Jet_btag{};
+std::vector<std::array<double, BtagSF::nShiftTypes>> BtagSF::scalefactors{};
+
+std::array<std::string, BtagSF::nShiftTypes> BtagSF::shiftNames{{
+  "central",
+  "up_jes",
+  "down_jes",
+  "up_hf",
+  "down_hf",
+  "up_lf",
+  "down_lf",
+  "up_hfstats1",
+  "down_hfstats1",
+  "up_hfstats2",
+  "down_hfstats2",
+  "up_lfstats1",
+  "down_lfstats1",
+  "up_lfstats2",
+  "down_lfstats2",
+  "up_cferr1",
+  "down_cferr1",
+  "up_cferr2",
+  "down_cferr2"
+}};
+
+std::array<std::vector<unsigned>, 3> BtagSF::relevantShifts{};
+
+BtagSF::BtagSF(char const* filename, char const* shift/* = "central"*/, char const* algo/* = "deepcsv"*/) :
+  TTreeFunction(),
+  filename_{filename},
+  shiftStr_{shift},
+  shift_{static_cast<unsigned>(std::find(shiftNames.begin(), shiftNames.end(), shiftStr_) - shiftNames.begin())},
+  algo_{algo}
+{
+  if (shift_ == nShiftTypes)
+    throw std::invalid_argument("Unknown shift name " + shiftStr_);
+}
+
+void
+BtagSF::beginEvent(long long _iEntry)
+{
+  setValues(_iEntry);
+}
+
+unsigned
+BtagSF::getNdata()
+{
+  return scalefactors.size();
+}
+
+double
+BtagSF::evaluate(unsigned iJ)
+{
+  return scalefactors[iJ][shift_];
+}
+
+void
+BtagSF::setValues(long long _iEntry)
+{
+  if (_iEntry == currentEntry)
+    return;
+
+  currentEntry = _iEntry;
+
+  scalefactors.clear();
+
+  unsigned nJ{*nJet->Get()};
+  scalefactors.resize(nJ);
+  
+  for (unsigned iJ{0}; iJ != nJ; ++iJ) {
+    BTagEntry::JetFlavor jf;
+  
+    switch (Jet_hadronFlavour->At(iJ)) {
+    case 5:
+      jf = BTagEntry::FLAV_B; // = 0
+      break;
+    case 4:
+      jf = BTagEntry::FLAV_C; // = 1
+      break;
+    default:
+      jf = BTagEntry::FLAV_UDSG; // = 2
+      break;
+    }
+
+    double central{readers[jf]->eval_auto_bounds("central", jf, std::abs(Jet_eta->At(iJ)), Jet_pt->At(iJ), Jet_btag->At(iJ))};
+
+    // set all shifts to central first
+    std::fill_n(scalefactors[iJ].begin(), nShiftTypes, central);
+
+    // then fill the actual shift values for relevant types
+    for (auto s : relevantShifts[jf])
+      scalefactors[iJ][s] = readers[jf]->eval_auto_bounds(shiftNames[s], jf, std::abs(Jet_eta->At(iJ)), Jet_pt->At(iJ), Jet_btag->At(iJ));
+  }
+}
+
+void
+BtagSF::bindTree_(multidraw::FunctionLibrary& _library)
+{
+  if (currentEntry == -2) {
+    std::cout << "Loading data for " << algo_ << " from " << filename_ << std::endl;
+
+    relevantShifts[BTagEntry::FLAV_B] = {kJESUp, kJESDown, kLFUp, kLFDown, kHFStats1Up, kHFStats1Down, kHFStats2Up, kHFStats2Down};
+    relevantShifts[BTagEntry::FLAV_C] = {kCFErr1Up, kCFErr1Down, kCFErr2Up, kCFErr2Down};
+    relevantShifts[BTagEntry::FLAV_UDSG] = {kJESUp, kJESDown, kHFUp, kHFDown, kLFStats1Up, kLFStats1Down, kLFStats2Up, kLFStats2Down};
+
+    readerFilename = filename_;
+    readerAlgo = algo_;
+
+    BTagCalibration calib(algo_, filename_);
+    for (auto flav : {BTagEntry::FLAV_B, BTagEntry::FLAV_C, BTagEntry::FLAV_UDSG}) {
+      std::vector<std::string> shiftsToRead;
+      for (auto s : relevantShifts[flav])
+        shiftsToRead.push_back(shiftNames[s]);
+      readers[flav].reset(new BTagCalibrationReader(BTagEntry::OP_RESHAPING, "central", shiftsToRead));
+      readers[flav]->load(calib, flav, "iterativefit");
+    }
+
+    std::cout << "  done." << std::endl;
+
+    currentEntry = -1;
+    _library.bindBranch(nJet, "nJet");
+    _library.bindBranch(Jet_pt, "Jet_pt");
+    _library.bindBranch(Jet_eta, "Jet_eta");
+    _library.bindBranch(Jet_hadronFlavour, "Jet_hadronFlavour");
+    if (algo_ == "deepcsv")
+      _library.bindBranch(Jet_btag, "Jet_btagDeepB");
+    else if (algo_ == "csvv2")
+      _library.bindBranch(Jet_btag, "Jet_btagCSVV2");
+    else if (algo_ == "deepjet")
+      _library.bindBranch(Jet_btag, "Jet_btagDeepFlavB");
+
+    _library.addDestructorCallback([]() {
+        currentEntry = -2;
+        nJet = nullptr;
+        Jet_pt = nullptr;
+        Jet_eta = nullptr;
+        Jet_hadronFlavour = nullptr;
+        Jet_btag = nullptr;
+        for (auto& reader : readers)
+          reader.reset();
+      });
+  }
+  else if (readerFilename != filename_ || readerAlgo != algo_) {
+    std::cerr << "BtagSF module configured for " << readerFilename << " and " << readerAlgo << " already." << std::endl;
+    std::cerr << "You cannot create an instance for " << filename_ << " and " << algo_ << " because the module is" << std::endl;
+    std::cerr << "written in a hacky way using static global variables." << std::endl;
+    throw std::invalid_argument(filename_ + "/" + algo_);
+  }
+}

--- a/Configurations/ggH/Full2016_nanoAODv4/aliases.py
+++ b/Configurations/ggH/Full2016_nanoAODv4/aliases.py
@@ -29,25 +29,47 @@ aliases['btag2'] = {
          )' 
 }
 
+# Temporary patch for BTV postprocessor bug (no SF for eta < 0, <= 102X_nAODv5_Full2018v5)
+
+btagSFSource = '%s/src/PhysicsTools/NanoAODTools/data/btagSF/DeepCSV_2016LegacySF_V1.csv' % os.getenv('CMSSW_BASE')
+
+aliases['Jet_btagSF_shapeFix'] = {
+    'linesToAdd': [
+        'gSystem->Load("libCondFormatsBTauObjects.so");',
+        'gSystem->Load("libCondToolsBTau.so");',
+        'gSystem->AddIncludePath("-I%s/src");' % os.getenv('CMSSW_RELEASE_BASE'),
+        '.L %s/src/PlotsConfigurations/Configurations/btagsfpatch.cc+' % os.getenv('CMSSW_BASE')
+    ],
+    'class': 'BtagSF',
+    'args': (btagSFSource,),
+    'samples': mc
+}
+
 aliases['bVetoSF'] = {
-'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5) ) ) ) )',
+#'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5) ) ) ) )',
+'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5) ) ) ) )',
 'samples': mc
 }
 
 
 aliases['btag0SF'] = {
-'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5) ) ) ) )',
+#'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5) ) ) ) )',
+'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5) ) ) ) )',
 'samples': mc
 }
 
 aliases['btag1SF'] = {
-'expr': '( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )',
+#'expr': '( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )',
+'expr': '( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shapeFix[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )',
 'samples': mc
 }
 
 aliases['btag2SF'] = {
-'expr': '( ( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )* \
-           ( ( Alt$(CleanJet_pt[1], 0)>30 && Alt$(abs(CleanJet_eta[1]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[1]], 1) ) + ( Alt$(CleanJet_pt[1], 0)<30 || Alt$(abs(CleanJet_eta[1]),99)>2.5 ) ) )\
+#'expr': '( ( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )* \
+#           ( ( Alt$(CleanJet_pt[1], 0)>30 && Alt$(abs(CleanJet_eta[1]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[1]], 1) ) + ( Alt$(CleanJet_pt[1], 0)<30 || Alt$(abs(CleanJet_eta[1]),99)>2.5 ) ) )\
+#        ',
+'expr': '( ( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shapeFix[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )* \
+           ( ( Alt$(CleanJet_pt[1], 0)>30 && Alt$(abs(CleanJet_eta[1]),99)<2.5 )*( Alt$(Jet_btagSF_shapeFix[CleanJet_jetIdx[1]], 1) ) + ( Alt$(CleanJet_pt[1], 0)<30 || Alt$(abs(CleanJet_eta[1]),99)>2.5 ) ) )\
         ',
 'samples': mc
 }
@@ -61,6 +83,19 @@ aliases['btagSF'] = {
 systs = ['jes','lf','hf','lfstats1','lfstats2','hfstats1','hfstats2','cferr1','cferr2']
 
 for s in systs:
-  aliases['btagSF'+s+'up'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_up_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_up_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_up_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_up_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
-  aliases['btagSF'+s+'down'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_down_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_down_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_down_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_down_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    aliases['Jet_btagSF_shapeFix_up_%s' % s] = {
+        'class': 'BtagSF',
+        'args': (btagSFSource, 'up_' + s),
+        'samples': mc
+    }
+    aliases['Jet_btagSF_shapeFix_down_%s' % s] = {
+        'class': 'BtagSF',
+        'args': (btagSFSource, 'down_' + s),
+        'samples': mc
+    }
+
+    #aliases['btagSF'+s+'up'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_up_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_up_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_up_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_up_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    aliases['btagSF'+s+'up'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shapeFix','shapeFix_up_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shapeFix','shapeFix_up_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shapeFix','shapeFix_up_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shapeFix','shapeFix_up_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    #aliases['btagSF'+s+'down'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_down_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_down_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_down_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_down_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    aliases['btagSF'+s+'down'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shapeFix','shapeFix_down_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shapeFix','shapeFix_down_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shapeFix','shapeFix_down_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shapeFix','shapeFix_down_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
 

--- a/Configurations/ggH/Full2017/aliases.py
+++ b/Configurations/ggH/Full2017/aliases.py
@@ -32,26 +32,48 @@ aliases['btag2'] = {
          )' 
 }
 
+# Temporary patch for BTV postprocessor bug (no SF for eta < 0, <= 102X_nAODv5_Full2018v5)
+
+btagSFSource = '%s/src/PhysicsTools/NanoAODTools/data/btagSF/DeepCSV_94XSF_V2_B_F.csv' % os.getenv('CMSSW_BASE')
+
+aliases['Jet_btagSF_shapeFix'] = {
+    'linesToAdd': [
+        'gSystem->Load("libCondFormatsBTauObjects.so");',
+        'gSystem->Load("libCondToolsBTau.so");',
+        'gSystem->AddIncludePath("-I%s/src");' % os.getenv('CMSSW_RELEASE_BASE'),
+        '.L %s/src/PlotsConfigurations/Configurations/btagsfpatch.cc+' % os.getenv('CMSSW_BASE')
+    ],
+    'class': 'BtagSF',
+    'args': (btagSFSource,),
+    'samples': mc
+}
+
 # NB These scale factors depend on the selections defined above, if different selections are used also the following expressions need to be changed!
 aliases['bVetoSF'] = {
-'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5) ) ) ) )',
+#'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5) ) ) ) )',
+'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5) ) ) ) )',
 'samples': mc
 }
 
 
 aliases['btag0SF'] = {
-'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5) ) ) ) )',
+#'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5) ) ) ) )',
+'expr': '( TMath::Exp(Sum$( TMath::Log( (CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5) ) ) ) )',
 'samples': mc
 }
 
 aliases['btag1SF'] = {
-'expr': '( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )',
+#'expr': '( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )',
+'expr': '( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shapeFix[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )',
 'samples': mc
 }
 
 aliases['btag2SF'] = {
-'expr': '( ( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )* \
-           ( ( Alt$(CleanJet_pt[1], 0)>30 && Alt$(abs(CleanJet_eta[1]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[1]], 1) ) + ( Alt$(CleanJet_pt[1], 0)<30 || Alt$(abs(CleanJet_eta[1]),99)>2.5 ) ) )\
+#'expr': '( ( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )* \
+#           ( ( Alt$(CleanJet_pt[1], 0)>30 && Alt$(abs(CleanJet_eta[1]),99)<2.5 )*( Alt$(Jet_btagSF_shape[CleanJet_jetIdx[1]], 1) ) + ( Alt$(CleanJet_pt[1], 0)<30 || Alt$(abs(CleanJet_eta[1]),99)>2.5 ) ) )\
+#        ',
+'expr': '( ( ( Alt$(CleanJet_pt[0], 0)>30 && Alt$(abs(CleanJet_eta[0]),99)<2.5 )*( Alt$(Jet_btagSF_shapeFix[CleanJet_jetIdx[0]], 1) ) + ( Alt$(CleanJet_pt[0], 0)<30 || Alt$(abs(CleanJet_eta[0]),99)>2.5 ) )* \
+           ( ( Alt$(CleanJet_pt[1], 0)>30 && Alt$(abs(CleanJet_eta[1]),99)<2.5 )*( Alt$(Jet_btagSF_shapeFix[CleanJet_jetIdx[1]], 1) ) + ( Alt$(CleanJet_pt[1], 0)<30 || Alt$(abs(CleanJet_eta[1]),99)>2.5 ) ) )\
         ',
 'samples': mc
 }
@@ -65,6 +87,19 @@ aliases['btagSF'] = {
 systs = ['jes','lf','hf','lfstats1','lfstats2','hfstats1','hfstats2','cferr1','cferr2']
 
 for s in systs:
-  aliases['btagSF'+s+'up'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_up_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_up_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_up_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_up_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
-  aliases['btagSF'+s+'down'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_down_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_down_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_down_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_down_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    aliases['Jet_btagSF_shapeFix_up_%s' % s] = {
+        'class': 'BtagSF',
+        'args': (btagSFSource, 'up_' + s),
+        'samples': mc
+    }
+    aliases['Jet_btagSF_shapeFix_down_%s' % s] = {
+        'class': 'BtagSF',
+        'args': (btagSFSource, 'down_' + s),
+        'samples': mc
+    }
+
+    #aliases['btagSF'+s+'up'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_up_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_up_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_up_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_up_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    aliases['btagSF'+s+'up'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shapeFix','shapeFix_up_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shapeFix','shapeFix_up_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shapeFix','shapeFix_up_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shapeFix','shapeFix_up_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    #aliases['btagSF'+s+'down'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shape','shape_down_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shape','shape_down_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shape','shape_down_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shape','shape_down_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
+    aliases['btagSF'+s+'down'] = { 'expr': '( bVeto*'+aliases['bVetoSF']['expr'].replace('shapeFix','shapeFix_down_'+s)+'+btag0*'+aliases['btag0SF']['expr'].replace('shapeFix','shapeFix_down_'+s)+'+btag1*'+aliases['btag1SF']['expr'].replace('shapeFix','shapeFix_down_'+s)+'+btag2*'+aliases['btag2SF']['expr'].replace('shapeFix','shapeFix_down_'+s)+' + ( (!bVeto) && (!btag0) && (!btag1) && (!btag2) ) )', 'samples':mc  }
 

--- a/Configurations/ggH/Full2018/aliases.py
+++ b/Configurations/ggH/Full2018/aliases.py
@@ -45,18 +45,37 @@ aliases['btag2'] = {
     'expr': 'twoJet && bReq'
 }
 
+# Temporary patch for BTV postprocessor bug (no SF for eta < 0, <= 102X_nAODv5_Full2018v5)
+
+btagSFSource = '%s/src/PhysicsTools/NanoAODTools/data/btagSF/DeepCSV_102XSF_V1.csv' % os.getenv('CMSSW_BASE')
+
+aliases['Jet_btagSF_shapeFix'] = {
+    'linesToAdd': [
+        'gSystem->Load("libCondFormatsBTauObjects.so");',
+        'gSystem->Load("libCondToolsBTau.so");',
+        'gSystem->AddIncludePath("-I%s/src");' % os.getenv('CMSSW_RELEASE_BASE'),
+        '.L %s/src/PlotsConfigurations/Configurations/btagsfpatch.cc+' % os.getenv('CMSSW_BASE')
+    ],
+    'class': 'BtagSF',
+    'args': (btagSFSource,),
+    'samples': mc
+}
+
 aliases['bVetoSF'] = {
-    'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5))))',
+    #'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5))))',
+    'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>20 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx]+1*(CleanJet_pt<20 || abs(CleanJet_eta)>2.5))))',
     'samples': mc
 }
 
 aliases['btag0SF'] = {
-    'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5))))',
+    #'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5))))',
+    'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>20 && CleanJet_pt<30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx]+1*(CleanJet_pt<20 || CleanJet_pt>30 || abs(CleanJet_eta)>2.5))))',
     'samples': mc
 }
 
 aliases['btagnSF'] = {
-    'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx] + (CleanJet_pt<30 || abs(CleanJet_eta)>2.5))))',
+    #'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shape[CleanJet_jetIdx] + (CleanJet_pt<30 || abs(CleanJet_eta)>2.5))))',
+    'expr': 'TMath::Exp(Sum$(TMath::Log((CleanJet_pt>30 && abs(CleanJet_eta)<2.5)*Jet_btagSF_shapeFix[CleanJet_jetIdx] + (CleanJet_pt<30 || abs(CleanJet_eta)>2.5))))',
     'samples': mc
 }
 
@@ -66,12 +85,25 @@ aliases['btagSF'] = {
 }
 
 for shift in ['jes','lf','hf','lfstats1','lfstats2','hfstats1','hfstats2','cferr1','cferr2']:
+    aliases['Jet_btagSF_shapeFix_up_%s' % shift] = {
+        'class': 'BtagSF',
+        'args': (btagSFSource, 'up_' + shift),
+        'samples': mc
+    }
+    aliases['Jet_btagSF_shapeFix_down_%s' % shift] = {
+        'class': 'BtagSF',
+        'args': (btagSFSource, 'down_' + shift),
+        'samples': mc
+    }
+
     for targ in ['bVeto', 'btag0', 'btagn']:
         alias = aliases['%sSF%sup' % (targ, shift)] = copy.deepcopy(aliases['%sSF' % targ])
-        alias['expr'] = alias['expr'].replace('btagSF_shape', 'btagSF_shape_up_%s' % shift)
+        #alias['expr'] = alias['expr'].replace('btagSF_shape', 'btagSF_shape_up_%s' % shift)
+        alias['expr'] = alias['expr'].replace('btagSF_shapeFix', 'btagSF_shapeFix_up_%s' % shift)
 
         alias = aliases['%sSF%sdown' % (targ, shift)] = copy.deepcopy(aliases['%sSF' % targ])
-        alias['expr'] = alias['expr'].replace('btagSF_shape', 'btagSF_shape_down_%s' % shift)
+        #alias['expr'] = alias['expr'].replace('btagSF_shape', 'btagSF_shape_down_%s' % shift)
+        alias['expr'] = alias['expr'].replace('btagSF_shapeFix', 'btagSF_shapeFix_down_%s' % shift)
 
     aliases['btagSF%sup' % shift] = {
         'expr': 'bVetoSF{shift}up*bVeto + btag0SF{shift}up*btag0 + btagnSF{shift}up*(btag1 + btag2) + (!bVeto && !btag0 && !btag1 && !btag2)'.format(shift = shift),


### PR DESCRIPTION
Adding a temporary patch for btagSF fix to ggH configurations, which should serve as templates for other analyses.
This patch requires the latest MultiDraw version (2.0.8) and LatinoAnalysis. LatinosSetup is updated with the MultiDraw tag.