### PR TITLE
Quark Gluon Likelihood generic morphing

### DIFF
--- a/Configurations/macros/qgl_morphing.cc
+++ b/Configurations/macros/qgl_morphing.cc
@@ -1,74 +1,73 @@
+/*
+ *  QG likelihood morphing
+ */
+
 #include "LatinoAnalysis/MultiDraw/interface/TTreeFunction.h"
 #include "LatinoAnalysis/MultiDraw/interface/FunctionLibrary.h"
 
-#include <vector>
-#include <array>
-#include <map>
+#include "TSystem.h"
+
 #include <iostream>
-#include <fstream>
-#include <sstream>
-#include <string>
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <iterator>
 
+#include "TLorentzVector.h"
+#include "TMath.h"
 
-
-#include "TVector2.h"
 #include "TString.h"
 #include "TGraph.h"
-#include "TFile.h"
-#include "TH2.h"
-#include "TH2F.h"
-#include "Math/Vector4Dfwd.h"
-#include "Math/GenVector/LorentzVector.h"
-#include "Math/GenVector/PtEtaPhiM4D.h"
-
-#include <iostream>
 
 
 #ifndef QGL_morphing_def
 #define QGL_morphing_def
 
-class QGL_morphing : public multidraw::TTreeFunction {
 
+class QGL_morphing : public multidraw::TTreeFunction {
 public:
-  
+  QGL_morphing();
   QGL_morphing( char const* fileNameWithRootFilesOfCorrection );
-  ~QGL_morphing();
   
   char const* getName() const override { return "QGL_morphing"; }
-  TTreeFunction* clone() const override { return new QGL_morphing(_fileNameWithRootFilesOfCorrection.c_str());}
+  TTreeFunction* clone() const override { return new QGL_morphing(_fileNameWithRootFilesOfCorrection);}  
+//   TTreeFunction* clone() const override { return new QGL_morphing(); }
   
-  void beginEvent(long long) override;
   unsigned getNdata() override { return _new_Jet_qgl.size(); } // size of the vector of jets
   int getMultiplicity() override { return 1; }
+  
+  void beginEvent(long long) override;
+  
+  
   double evaluate(unsigned) override;
   
 protected:
-  
   void bindTree_(multidraw::FunctionLibrary&) override;
+  
+//   UIntValueReader* nLepton;
   
   FloatArrayReader* Jet_pt{};
   FloatArrayReader* Jet_eta{};
   FloatArrayReader* Jet_qgl{};
   
-//   IntArrayReader*   Lepton_pdgId{};
-    
-  std::string _fileNameWithRootFilesOfCorrection{};  
+  TString _fileNameWithRootFilesOfCorrection{};  
   static std::map<std::string, TGraph*> morphing_functions;
   
   std::vector<float> _new_Jet_qgl;
   
+  
 };
 
 
-QGL_morphing::QGL_morphing(char const* fileNameWithRootFilesOfCorrection) :
-        TTreeFunction(),
-        _fileNameWithRootFilesOfCorrection{fileNameWithRootFilesOfCorrection} {
-          
-// Reading the file and extract TGraphs
-//           
-//           fileNameWithRootFilesOfCorrection
-// 
-        
+QGL_morphing::QGL_morphing() :
+TTreeFunction() {
+  
+}
+
+
+QGL_morphing::QGL_morphing( char const* fileNameWithRootFilesOfCorrection ) :
+TTreeFunction(),
+_fileNameWithRootFilesOfCorrection(fileNameWithRootFilesOfCorrection) {
   
 }
 
@@ -84,15 +83,19 @@ void QGL_morphing::beginEvent(long long _iEntry) {
 
 
 double QGL_morphing::evaluate(unsigned iJ) {
+  
   if (iJ<_new_Jet_qgl.size()) return _new_Jet_qgl.at(iJ);
   else return -9999.;
+  
 }
 
 
 void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
+  std::cout << "Loading QGL_morphing" << std::endl;
   _library.bindBranch(Jet_pt, "Jet_pt");
   _library.bindBranch(Jet_eta, "Jet_eta");
   _library.bindBranch(Jet_qgl, "Jet_qgl");
+  
 }
 
 
@@ -110,5 +113,5 @@ void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
 //
 //
 
-#endif
 
+#endif

--- a/Configurations/macros/qgl_morphing.cc
+++ b/Configurations/macros/qgl_morphing.cc
@@ -13,6 +13,7 @@
 
 #include "TVector2.h"
 #include "TString.h"
+#include "TGraph.h"
 #include "TFile.h"
 #include "TH2.h"
 #include "TH2F.h"
@@ -23,16 +24,18 @@
 #include <iostream>
 
 
-#ifndef QGL_morphing
-#define QGL_morphing
+#ifndef QGL_morphing_def
+#define QGL_morphing_def
 
 class QGL_morphing : public multidraw::TTreeFunction {
+
 public:
-  QGL_morphing(char const* fileNameWithRootFilesOfCorrection);
+  
+  QGL_morphing( char const* fileNameWithRootFilesOfCorrection );
   ~QGL_morphing();
   
   char const* getName() const override { return "QGL_morphing"; }
-  TTreeFunction* clone() const override { return new QGL_morphing(_fileNameWithRootFilesOfCorrection);}
+  TTreeFunction* clone() const override { return new QGL_morphing(_fileNameWithRootFilesOfCorrection.c_str());}
   
   void beginEvent(long long) override;
   unsigned getNdata() override { return _new_Jet_qgl.size(); } // size of the vector of jets
@@ -49,7 +52,7 @@ protected:
   
 //   IntArrayReader*   Lepton_pdgId{};
     
-  TString _fileNameWithRootFilesOfCorrection{};  
+  std::string _fileNameWithRootFilesOfCorrection{};  
   static std::map<std::string, TGraph*> morphing_functions;
   
   std::vector<float> _new_Jet_qgl;
@@ -61,7 +64,7 @@ QGL_morphing::QGL_morphing(char const* fileNameWithRootFilesOfCorrection) :
         TTreeFunction(),
         _fileNameWithRootFilesOfCorrection{fileNameWithRootFilesOfCorrection} {
           
-  // Reading the file and extract TGraphs
+// Reading the file and extract TGraphs
 //           
 //           fileNameWithRootFilesOfCorrection
 // 
@@ -76,7 +79,6 @@ void QGL_morphing::beginEvent(long long _iEntry) {
   // Fill the new vector _new_Jet_qgl
   //
   //
-  
   
 }
 
@@ -109,3 +111,4 @@ void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
 //
 
 #endif
+

--- a/Configurations/macros/qgl_morphing.cc
+++ b/Configurations/macros/qgl_morphing.cc
@@ -1,0 +1,98 @@
+#include "LatinoAnalysis/MultiDraw/interface/TTreeFunction.h"
+#include "LatinoAnalysis/MultiDraw/interface/FunctionLibrary.h"
+
+#include <vector>
+#include <array>
+#include <map>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+
+
+#include "TVector2.h"
+#include "TString.h"
+#include "TFile.h"
+#include "TH2.h"
+#include "TH2F.h"
+#include "Math/Vector4Dfwd.h"
+#include "Math/GenVector/LorentzVector.h"
+#include "Math/GenVector/PtEtaPhiM4D.h"
+
+#include <iostream>
+
+
+#ifndef QGL_morphing
+#define QGL_morphing
+
+class QGL_morphing : public multidraw::TTreeFunction {
+public:
+  QGL_morphing(char const* fileNameWithRootFilesOfCorrection);
+  ~QGL_morphing();
+  
+  char const* getName() const override { return "QGL_morphing"; }
+  TTreeFunction* clone() const override { return new QGL_morphing(_values);}
+  
+  void beginEvent(long long) override;
+  unsigned getNdata() override { return _new_Jet_qgl.size(); } // size of the vector of jets
+  int getMultiplicity() override { return 1; }
+  double evaluate(unsigned) override;
+  
+protected:
+  
+  void bindTree_(multidraw::FunctionLibrary&) override;
+  
+  FloatArrayReader* Jet_pt{};
+  FloatArrayReader* Jet_eta{};
+  FloatArrayReader* Jet_qgl{};
+  
+//   IntArrayReader*   Lepton_pdgId{};
+    
+  TString _fileNameWithRootFilesOfCorrection{};  
+  static std::map<std::string, TGraph*> morphing_functions;
+  
+  std::vector<float> _new_Jet_qgl;
+  
+};
+
+
+QGL_morphing::QGL_morphing(char const* fileNameWithRootFilesOfCorrection) :
+        TTreeFunction(),
+        _fileNameWithRootFilesOfCorrection{fileNameWithRootFilesOfCorrection} {
+          
+  // Reading the file and extract TGraphs
+//           
+//           fileNameWithRootFilesOfCorrection
+// 
+        
+  
+}
+
+
+void QGL_morphing::beginEvent(long long _iEntry) {
+  
+  //
+  // Fill the new vector _new_Jet_qgl
+  //
+  //
+  
+  
+}
+
+
+double QGL_morphing::evaluate(unsigned iJ) {
+  if (iJ<_new_Jet_qgl.size()) return _new_Jet_qgl.at(iJ);
+  else return -9999.;
+}
+
+
+void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
+  _library.bindBranch(Jet_pt, "Jet_pt");
+  _library.bindBranch(Jet_eta, "Jet_eta");
+  _library.bindBranch(Jet_qgl, "Jet_qgl");
+}
+
+
+
+#endif

--- a/Configurations/macros/qgl_morphing.cc
+++ b/Configurations/macros/qgl_morphing.cc
@@ -18,10 +18,28 @@
 
 #include "TString.h"
 #include "TGraph.h"
+#include "TFile.h"
 
 
 #ifndef QGL_morphing_def
 #define QGL_morphing_def
+
+
+
+namespace multidraw {
+  extern thread_local TTree* currentTree;
+}
+
+
+int isRunningSample(TString targetSample){
+  TString currentSampleName = TString(multidraw::currentTree->GetCurrentFile()->GetName());
+  if ( currentSampleName.Contains(targetSample)) {
+    return 1;
+  }
+  else return 0;
+}
+
+
 
 
 class QGL_morphing : public multidraw::TTreeFunction {
@@ -37,8 +55,7 @@ public:
   int getMultiplicity() override { return 1; }
   
   void beginEvent(long long) override;
-  
-  
+ 
   double evaluate(unsigned) override;
   
 protected:
@@ -46,17 +63,23 @@ protected:
   
 //   UIntValueReader* nLepton;
   
-  FloatArrayReader* Jet_pt{};
-  FloatArrayReader* Jet_eta{};
+  UIntValueReader* nCleanJet;
+  FloatArrayReader* CleanJet_eta{};
+  FloatArrayReader* CleanJet_pt{};
+  IntArrayReader*   CleanJet_jetIdx{};
   FloatArrayReader* Jet_qgl{};
   
+ 
+  
   TString _fileNameWithRootFilesOfCorrection{};  
-  static std::map<std::string, TGraph*> morphing_functions;
+  static std::map<std::string, TGraph*> _morphing_functions;
   
   std::vector<float> _new_Jet_qgl;
   
   
 };
+
+std::map<std::string, TGraph*> QGL_morphing::_morphing_functions{};
 
 
 QGL_morphing::QGL_morphing() :
@@ -69,6 +92,17 @@ QGL_morphing::QGL_morphing( char const* fileNameWithRootFilesOfCorrection ) :
 TTreeFunction(),
 _fileNameWithRootFilesOfCorrection(fileNameWithRootFilesOfCorrection) {
   
+  TFile rfile {_fileNameWithRootFilesOfCorrection.Data(), "READ"};
+  QGL_morphing::_morphing_functions["gluon_loweta_pt0"]  = (TGraph*) rfile.Get("j3_loweta_pt0_gluon" );
+  QGL_morphing::_morphing_functions["gluon_loweta_pt1"]  = (TGraph*) rfile.Get("j3_loweta_pt1_gluon" );
+  QGL_morphing::_morphing_functions["gluon_higheta_pt0"] = (TGraph*) rfile.Get("j1_higheta_pt0_gluon");
+  QGL_morphing::_morphing_functions["gluon_higheta_pt1"] = (TGraph*) rfile.Get("j1_higheta_pt1_gluon");
+  QGL_morphing::_morphing_functions["quark_loweta_pt0"]  = (TGraph*) rfile.Get("j1_loweta_pt0_quark" );
+  QGL_morphing::_morphing_functions["quark_loweta_pt1"]  = (TGraph*) rfile.Get("j1_loweta_pt1_quark" );
+  QGL_morphing::_morphing_functions["quark_higheta_pt0"] = (TGraph*) rfile.Get("j1_higheta_pt0_quark");
+  QGL_morphing::_morphing_functions["quark_higheta_pt1"] = (TGraph*) rfile.Get("j0_higheta_pt1_quark");
+  rfile.Close();
+  
 }
 
 
@@ -78,6 +112,41 @@ void QGL_morphing::beginEvent(long long _iEntry) {
   // Fill the new vector _new_Jet_qgl
   //
   //
+  
+  _new_Jet_qgl.clear();
+  unsigned int total_jets{*nCleanJet->Get()};
+  for (unsigned int iCleanJet=0; iCleanJet<total_jets ; iCleanJet++) {
+    float eta = CleanJet_eta->At(iCleanJet);
+    float pt  = CleanJet_pt->At(iCleanJet);
+    float qgl = Jet_qgl->At(CleanJet_jetIdx->At(iCleanJet));
+  
+    //
+    // modify qgl 
+    //
+    
+    if (qgl > 0.0 && qgl < 1.0) {
+      float y = qgl;
+      if (abs(eta)<3 && pt < 75) {
+        y =  QGL_morphing::_morphing_functions["gluon_loweta_pt0"]->Eval(qgl);
+      }
+      if (abs(eta)<3 && pt >= 75) {
+        y =  QGL_morphing::_morphing_functions["gluon_loweta_pt1"]->Eval(qgl);
+      }
+      if (abs(eta)>=3 && pt < 75) {
+        y =  QGL_morphing::_morphing_functions["gluon_higheta_pt0"]->Eval(qgl);
+      }
+      if (abs(eta)>=3 && pt >= 75) {
+        y =  QGL_morphing::_morphing_functions["gluon_higheta_pt1"]->Eval(qgl);
+      }
+      
+      // it should never happen, but you never know ...
+      if (y<0.0 ) y=0.0;
+      if (y>1.0 ) y=1.0;
+      
+      qgl = y;
+    }
+    _new_Jet_qgl.push_back(qgl);
+  }
   
 }
 
@@ -92,9 +161,16 @@ double QGL_morphing::evaluate(unsigned iJ) {
 
 void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
   std::cout << "Loading QGL_morphing" << std::endl;
-  _library.bindBranch(Jet_pt, "Jet_pt");
-  _library.bindBranch(Jet_eta, "Jet_eta");
-  _library.bindBranch(Jet_qgl, "Jet_qgl");
+  
+  _library.bindBranch(Jet_qgl, "Jet_qgl");  
+  _library.bindBranch(CleanJet_eta, "CleanJet_eta");
+  _library.bindBranch(CleanJet_pt, "CleanJet_pt");
+  _library.bindBranch(CleanJet_jetIdx, "CleanJet_jetIdx");
+  _library.bindBranch(nCleanJet, "nCleanJet");
+  
+  _library.addDestructorCallback([]() {
+    _morphing_functions.clear();
+   });
   
 }
 
@@ -102,16 +178,35 @@ void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
 //
 // to be used like this:
 //
-//  aliases['Jet_qgl_morphed'] = {
-//    'class': 'QglVarsMorphing',
-//    'args': ('blabla.txt'),
-//    'linesToAdd' : [
-//    'gSystem->Load("libLatinoAnalysisMultiDraw.so")',
-//    '.L {}/macros/qgl_vars_morphing.cc+'.format(configurations)
-//    ] 
-//  } 
+//  
+//      
+//      ###################################3
+//      # QGL variables
+//      morphing_file = "/afs/cern.ch/user/d/dvalsecc/public/qgl_morphing/morphing_functions_final_2018.root"
+//      # /afs/cern.ch/user/d/dvalsecc/public/qgl_morphing/morphing_functions_final_2016.root    --> for 2016
+//      # /afs/cern.ch/user/d/dvalsecc/public/qgl_morphing/morphing_functions_final_2018.root    --> for 2017 (same as 2018)
+//      # /afs/cern.ch/user/d/dvalsecc/public/qgl_morphing/morphing_functions_final_2018.root    --> for 2018
+//      
+//      ###############
+//      aliases['CleanJet_qgl_morphed'] = {
+//        'class': 'QGL_morphing',
+//        'args': (morphing_file),
+//        'linesToAdd' : [
+//        'gSystem->Load("libLatinoAnalysisMultiDraw.so")',
+//        '.L {}/macros/qgl_morphing.cc+'.format(configurations)
+//        ] 
+//      } 
+//      
+//      
+//  and as variable:
 //
 //
-
+//        variables['Jet_qgl_morphed_0']  = {   'name': 'CleanJet_qgl_morphed[0]',
+//          'range' : (100,-10,1),
+//          'xaxis' : 'qgl morphed test',
+//          'fold' : 3
+//        }
+//        
+//        
 
 #endif

--- a/Configurations/macros/qgl_morphing.cc
+++ b/Configurations/macros/qgl_morphing.cc
@@ -32,7 +32,7 @@ public:
   ~QGL_morphing();
   
   char const* getName() const override { return "QGL_morphing"; }
-  TTreeFunction* clone() const override { return new QGL_morphing(_values);}
+  TTreeFunction* clone() const override { return new QGL_morphing(_fileNameWithRootFilesOfCorrection);}
   
   void beginEvent(long long) override;
   unsigned getNdata() override { return _new_Jet_qgl.size(); } // size of the vector of jets
@@ -94,5 +94,18 @@ void QGL_morphing::bindTree_(multidraw::FunctionLibrary& _library) {
 }
 
 
+//
+// to be used like this:
+//
+//  aliases['Jet_qgl_morphed'] = {
+//    'class': 'QglVarsMorphing',
+//    'args': ('blabla.txt'),
+//    'linesToAdd' : [
+//    'gSystem->Load("libLatinoAnalysisMultiDraw.so")',
+//    '.L {}/macros/qgl_vars_morphing.cc+'.format(configurations)
+//    ] 
+//  } 
+//
+//
 
 #endif

--- a/Configurations/macros/qgl_morphing.cc
+++ b/Configurations/macros/qgl_morphing.cc
@@ -68,7 +68,7 @@ protected:
   FloatArrayReader* CleanJet_pt{};
   IntArrayReader*   CleanJet_jetIdx{};
   FloatArrayReader* Jet_qgl{};
-  FloatArrayReader* Jet_partonFlavour{};
+  IntArrayReader* Jet_partonFlavour{};
   
   
  
@@ -127,11 +127,12 @@ void QGL_morphing::beginEvent(long long _iEntry) {
     
     if (!QGL_morphing::_isRunningOnData){
       
+      //       std::cout << " it is not DATA " << std::endl;
       //
       // modify qgl 
       //
 
-      float flavour = Jet_partonFlavour->At(CleanJet_jetIdx->At(iCleanJet));
+      int flavour = Jet_partonFlavour->At(CleanJet_jetIdx->At(iCleanJet));
       
       if (qgl > 0.0 && qgl < 1.0) {
         float y = qgl;


### PR DESCRIPTION
Generic morphing for Quark Gluon likelihood.
See details in @valsdav presentation at SMP-VV
https://indico.cern.ch/event/978103/contributions/4120337/attachments/2149595/3624044/24_11_29%20-%20SMP-VV%20meeting%20-%20VBS%20WV%20semileptonic%20-%20Updates.pdf

**To be fully tested before merging.**

It creates a new vector (in aliases.py named "CleanJet_qgl_morphed"), already ordered according to CleanJet collection, with the values of the morphed QGlikelihood.

